### PR TITLE
Add navigation bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4649,9 +4649,9 @@
       "integrity": "sha512-U+QgsL8TZDU/n+rDnYDa3hY5uy3C4iry9mrJS0PNBBGwnocuQ+aHSfgY44mdlaK9744X5YqrrGUvD9PxCLY1HA=="
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
@@ -7868,9 +7868,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -28,10 +28,6 @@ function App() {
     }
   ]
 
-  useEffect(() => {    
-    return () => {}
-  }, [  ])
-
   return (
     <div className="App">
       <BrowserRouter>

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -1,38 +1,18 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import './App.css';
 
-import ExerciseBuilder from '../exercise-builder';
 import NavBar from '../navigation-bar';
 import { BrowserRouter } from 'react-router-dom';
-
-
+import Router, { appRoutes } from '../routes';
 
 function App() {
 
-  const appRoutes = [
-    {
-      to: '/monitores',
-      title: 'Monitores'
-    },
-    {
-      to: '/about',
-      title: 'Sobre',
-    },
-    {
-      to: '/materials',
-      title: 'Materiais',
-    },
-    {
-      to: '/extras',
-      title: 'Extras',
-    }
-  ]
 
   return (
     <div className="App">
       <BrowserRouter>
-        <NavBar routes={appRoutes}/>
-        <ExerciseBuilder/>
+        <NavBar routes={appRoutes.map(routerProps => ({ to: routerProps.path, title: routerProps.title }))}/>
+        <Router/>
       </BrowserRouter>
     </div>
   );

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -2,8 +2,31 @@ import React, { useEffect } from 'react';
 import './App.css';
 
 import ExerciseBuilder from '../exercise-builder';
+import NavBar from '../navigation-bar';
+import { BrowserRouter } from 'react-router-dom';
+
+
 
 function App() {
+
+  const appRoutes = [
+    {
+      to: '/monitores',
+      title: 'Monitores'
+    },
+    {
+      to: '/about',
+      title: 'Sobre',
+    },
+    {
+      to: '/materials',
+      title: 'Materiais',
+    },
+    {
+      to: '/extras',
+      title: 'Extras',
+    }
+  ]
 
   useEffect(() => {    
     return () => {}
@@ -11,7 +34,10 @@ function App() {
 
   return (
     <div className="App">
-      <ExerciseBuilder/>
+      <BrowserRouter>
+        <NavBar routes={appRoutes}/>
+        <ExerciseBuilder/>
+      </BrowserRouter>
     </div>
   );
 }

--- a/src/components/navigation-bar/index.js
+++ b/src/components/navigation-bar/index.js
@@ -6,7 +6,7 @@ import './styles/navigation-bar.css';
 /**
  * 
  * @param {Object} props
- * @param {{ href: String, title: String }[]} props.routes
+ * @param {{ to: String, title: String }[]} props.routes
  */
 const NavBar = function(props) {
   const { routes } = props;

--- a/src/components/navigation-bar/index.js
+++ b/src/components/navigation-bar/index.js
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Link from './link';
+import { useLocation } from 'react-router-dom';
+import './styles/navigation-bar.css';
 
 /**
  * 
@@ -8,11 +10,12 @@ import Link from './link';
  */
 const NavBar = function(props) {
   const { routes } = props;
+  const { pathname } = useLocation();
 
   return (
     <div className='Navbar'>
       {
-        routes.map(({ to, title }, idx) => <Link key={idx} to={to}>{title}</Link>)
+        routes.map(({ to, title }, idx) => <Link key={idx} to={to} selected={pathname === to}>{title}</Link>)
       }
     </div>
   )

--- a/src/components/navigation-bar/index.js
+++ b/src/components/navigation-bar/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import Link from './link';
 import { useLocation } from 'react-router-dom';
 import './styles/navigation-bar.css';

--- a/src/components/navigation-bar/index.js
+++ b/src/components/navigation-bar/index.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import Link from './link';
+
+/**
+ * 
+ * @param {Object} props
+ * @param {{ href: String, title: String }[]} props.routes
+ */
+const NavBar = function(props) {
+  const { routes } = props;
+
+  return (
+    <div className='Navbar'>
+      {
+        routes.map(({ to, title }, idx) => <Link key={idx} to={to}>{title}</Link>)
+      }
+    </div>
+  )
+}
+
+export default NavBar;

--- a/src/components/navigation-bar/link.js
+++ b/src/components/navigation-bar/link.js
@@ -1,8 +1,13 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import './styles/link.css';
 
 export default function(props) {
+  const { to, selected, children } = props;
   return (
-    <Link to={props.to}>{props.children}</Link>
+    <Link className={'Link' + (selected ? ' selected' : '')} 
+      to={to}>
+      {children}
+    </Link>
   )
 }

--- a/src/components/navigation-bar/link.js
+++ b/src/components/navigation-bar/link.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function(props) {
+  return (
+    <Link to={props.to}>{props.children}</Link>
+  )
+}

--- a/src/components/navigation-bar/navigation-bar.test.js
+++ b/src/components/navigation-bar/navigation-bar.test.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { unmountComponentAtNode } from 'react-dom';
+import { render, act, fireEvent } from '@testing-library/react';
+import NavigationBar from './index';
+import { BrowserRouter } from 'react-router-dom';
+
+let container = null;
+
+describe("NavigationBar component", () => {
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  })
+
+  afterEach(() => {
+    unmountComponentAtNode(container);
+    container.remove();
+    container = null;
+  })
+
+  test('render correct links', () => {
+    const mockRoutes = [
+      {
+        to: '/route1',
+        title: 'Rota 1'
+      },
+      {
+        to: '/route2',
+        title: 'Rota 2'
+      }
+    ];
+    const { getByText } = render(
+      <BrowserRouter>
+        <NavigationBar routes={mockRoutes}/>
+      </BrowserRouter>
+    )
+    const linkRoute1 = getByText(/Rota 1/);
+    const linkRoute2 = getByText(/Rota 2/);
+    expect(linkRoute1).toBeInTheDocument();
+    expect(linkRoute2).toBeInTheDocument();
+  });
+
+  test('changes location when clicking in link', () => {
+    const mockRoutes = [
+      {
+        to: '/route1',
+        title: 'Rota 1'
+      },
+      {
+        to: '/route2',
+        title: 'Rota 2'
+      }
+    ];
+    const { getByText } = render(
+      <BrowserRouter>
+        <NavigationBar routes={mockRoutes}/>
+      </BrowserRouter>
+    )
+    expect(window.location.pathname).not.toBe('/route1');
+    const linkRoute1 = getByText(/Rota 1/);
+    act(() => {
+      fireEvent.click(linkRoute1);
+    })
+    expect(window.location.pathname).toBe('/route1');
+
+  });
+})

--- a/src/components/navigation-bar/navigation-bar.test.js
+++ b/src/components/navigation-bar/navigation-bar.test.js
@@ -41,7 +41,7 @@ describe("NavigationBar component", () => {
     expect(linkRoute2).toBeInTheDocument();
   });
 
-  test('changes location when clicking in link with selected css class in navigation link clicked', () => {
+  test('changes location when clicking in a link, and add selected class to it', () => {
     const mockRoutes = [
       {
         to: '/route1',

--- a/src/components/navigation-bar/navigation-bar.test.js
+++ b/src/components/navigation-bar/navigation-bar.test.js
@@ -41,7 +41,7 @@ describe("NavigationBar component", () => {
     expect(linkRoute2).toBeInTheDocument();
   });
 
-  test('changes location when clicking in link', () => {
+  test('changes location when clicking in link with selected css class in navigation link clicked', () => {
     const mockRoutes = [
       {
         to: '/route1',
@@ -63,6 +63,6 @@ describe("NavigationBar component", () => {
       fireEvent.click(linkRoute1);
     })
     expect(window.location.pathname).toBe('/route1');
-
+    expect(linkRoute1.className.includes(' selected')).toBe(true);
   });
 })

--- a/src/components/navigation-bar/styles/link.css
+++ b/src/components/navigation-bar/styles/link.css
@@ -1,0 +1,10 @@
+.Link {
+  color: black;
+  display: inline-flex;
+  text-decoration: none;
+  padding-bottom: 5px;
+}
+
+.selected {
+  border-bottom: 1px solid black;
+}

--- a/src/components/navigation-bar/styles/navigation-bar.css
+++ b/src/components/navigation-bar/styles/navigation-bar.css
@@ -9,7 +9,6 @@
   flex-direction: row;
   justify-content: space-evenly;
   align-items: center;
-  border: 1px solid green;
 
   /* Centraliza navbar*/
   margin-left: auto;

--- a/src/components/navigation-bar/styles/navigation-bar.css
+++ b/src/components/navigation-bar/styles/navigation-bar.css
@@ -1,0 +1,17 @@
+.Navbar {
+  max-width: 600px;
+  min-width: 400px;
+  height: 50px;
+  background-color: #D16BEB;
+  
+  /* alinha itens */
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+  align-items: center;
+  border: 1px solid green;
+
+  /* Centraliza navbar*/
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/src/components/routes/about/index.js
+++ b/src/components/routes/about/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+const About = function(props) {
+  return (
+    <h1>About</h1>
+  )
+}
+
+export default About;

--- a/src/components/routes/extras/index.js
+++ b/src/components/routes/extras/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+const Extras = function(props) {
+  return (
+    <h1>Extras</h1>
+  )
+}
+
+export default Extras;

--- a/src/components/routes/home/index.js
+++ b/src/components/routes/home/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+const Home = function(props) {
+  return (
+    <h1>Menu</h1>
+  )
+}
+
+export default Home;

--- a/src/components/routes/index.js
+++ b/src/components/routes/index.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Route } from 'react-router';
+import About from './about';
+import Extras from './extras';
+import Home from './home';
+import Materials from './materials';
+import Monitores from './monitores';
+
+
+export const appRoutes = [
+  {
+    path: '/',
+    title: 'Home',
+    component: Home,
+    exact: true,
+  },
+  {
+    path: '/monitores',
+    title: 'Monitores',
+    component: Monitores,
+  },
+  {
+    path: '/about',
+    title: 'Sobre',
+    component: About,
+  },
+  {
+    path: '/materials',
+    title: 'Materiais',
+    component: Materials,
+  },
+  {
+    path: '/extras',
+    title: 'Extras',
+    component: Extras
+  }
+]
+
+const Router = function (props) {
+
+  return (
+    <>
+    {
+      appRoutes.map((routeProps) => <Route key={routeProps.path} {...routeProps}/>)
+    }
+    </>
+  )
+
+}
+
+export default Router;

--- a/src/components/routes/materials/index.js
+++ b/src/components/routes/materials/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+const Materials = function(props) {
+  return (
+    <h1>Materials</h1>
+  )
+}
+
+export default Materials;

--- a/src/components/routes/monitores/index.js
+++ b/src/components/routes/monitores/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+const Monitores = function(props) {
+  return (
+    <h1>Monitores</h1>
+  )
+}
+
+export default Monitores;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26746899/89088093-f8a96080-d36c-11ea-9da5-bd0d6f0a2e19.png)
![image](https://user-images.githubusercontent.com/26746899/89088290-d237f500-d36d-11ea-90e9-c8da9f41d25e.png)

Um componente pra essa navbar. Não coloquei o pipipi popopo, e coloquei uma navegação pra o Menu.
As rotas são definidas assim (no módulo routes):

```
export const appRoutes = [
  {
    path: '/',
    title: 'Home', // Acho que podemos repensar no nome dessa rota, coloquei ela pensando numa navegação para o Menu
    component: Home,
    exact: true,
  },
  {
    path: '/monitores',
    title: 'Monitores',
    component: Monitores,
  },
  {
    path: '/about',
    title: 'Sobre',
    component: About,
  },
  {
    path: '/materials',
    title: 'Materiais',
    component: Materials,
  },
  {
    path: '/extras',
    title: 'Extras',
    component: Extras
  }
]
```

Não seria interessantes ter uma modo de navegar direto pro submódulo de interesse? Podemos fazer isso com + 1 item de navegação, que abra com dropdowns (1 para escolher o módulo, imagino ele abrindo pra baixo, e outro pra escolher o submódulo, imagino ele abrindo pra um lado)